### PR TITLE
[Fix] Add positional arguments to async_setup

### DIFF
--- a/custom_components/northern_powergrid_power_cuts/__init__.py
+++ b/custom_components/northern_powergrid_power_cuts/__init__.py
@@ -13,7 +13,7 @@ DOMAIN = "northern_powergrid_power_cuts"
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
-async def async_setup():
+async def async_setup(hass, config):  # noqa: ARG001 - arguments are required by HA
     """Set up the Northern Powergrid Power Cuts component."""
     return True
 

--- a/custom_components/northern_powergrid_power_cuts/manifest.json
+++ b/custom_components/northern_powergrid_power_cuts/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/nosilleg/northern-powergrid-power-cuts/issues",
   "requirements": [],
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "northern-powergrid-power-cuts"
-version = "0.2.0"
+version = "0.2.1"
 description = "Home Assistant integration for Northern Powergrid power cuts"
 readme = "README.md"
 requires-python = "==3.13.3"

--- a/uv.lock
+++ b/uv.lock
@@ -1033,7 +1033,7 @@ wheels = [
 
 [[package]]
 name = "northern-powergrid-power-cuts"
-version = "0.2.0"
+version = "0.2.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Add positional arguments to async_setup and add lint exception comments, since the arguments are unused.

Fixes: #1 

